### PR TITLE
🐛 FIX: Mettre à jour les tables de relations en cas de suppression en cascade

### DIFF
--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -8,9 +8,9 @@ class Organization < ActiveRecord::Base
   validates_format_of :mail, :with => /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i, :allow_blank => true
 
   has_many :users, :dependent => :nullify
-  has_many :organization_roles
-  has_many :organization_managers
-  has_many :organization_team_leaders
+  has_many :organization_roles, :dependent => :destroy
+  has_many :organization_managers, :dependent => :destroy
+  has_many :organization_team_leaders, :dependent => :destroy
   has_many :managers, through: :organization_managers, :source => :user
   has_many :team_leaders, through: :organization_team_leaders, :source => :user
   has_many :organization_notifications

--- a/init.rb
+++ b/init.rb
@@ -9,6 +9,7 @@ require_dependency 'redmine_organizations/hooks/view_layouts_base_html_head_hook
 ActiveSupport::Reloader.to_prepare do
 
   require_dependency 'redmine_organizations/patches/user_patch'
+  require_dependency 'redmine_organizations/patches/role_patch'
   require_dependency 'redmine_organizations/patches/group_patch'
   require_dependency 'redmine_organizations/patches/issue_patch'
   require_dependency 'redmine_organizations/patches/issue_query_patch'

--- a/lib/redmine_organizations/patches/project_patch.rb
+++ b/lib/redmine_organizations/patches/project_patch.rb
@@ -4,7 +4,7 @@ require_dependency 'user'
 
 class Project < ActiveRecord::Base
 
-  has_many :organization_roles
+  has_many :organization_roles, :dependent => :destroy
   has_many :organization_notifications
   has_many :notified_organizations, through: :organization_notifications, :source => :organization
 

--- a/lib/redmine_organizations/patches/role_patch.rb
+++ b/lib/redmine_organizations/patches/role_patch.rb
@@ -1,5 +1,5 @@
 require_dependency "role"
 
-class Role
-  has_many :organization_roles
+class Role < ActiveRecord::Base
+  has_many :organization_roles, :dependent => :destroy
 end

--- a/lib/redmine_organizations/patches/user_patch.rb
+++ b/lib/redmine_organizations/patches/user_patch.rb
@@ -9,8 +9,8 @@ require_dependency 'user'
 
 class User < Principal
   belongs_to :organization
-  has_many :organization_managers
-  has_many :organization_team_leaders
+  has_many :organization_managers, :dependent => :destroy
+  has_many :organization_team_leaders, :dependent => :destroy
 
   scope :team_leader, -> { joins(:organization_team_leaders) }
 

--- a/spec/models/user_patch_spec.rb
+++ b/spec/models/user_patch_spec.rb
@@ -18,4 +18,12 @@ describe "UserPatch" do
     expect(User.find(2).organization).to eq Organization.find(2)
     expect(User.find(2).managers).to eq [User.find(2), User.find(1)]
   end
+
+  it "Update OrganizationManager, OrganizationTeamLeader tables, when deleting a user" do
+    user = User.find(2)
+    expect do
+      user.destroy
+    end.to change { OrganizationManager.count }.by(-1)
+    .and change { OrganizationTeamLeader.count }.by(-1)
+  end
 end


### PR DESCRIPTION
- Mettre à jour les tables de relations (OrganizationRole, OrganizationManager, OrganizationTeamLeader) en cas de suppression en cascade 
-  Test