### PR TITLE
Deleting all members of an organization

### DIFF
--- a/app/controllers/organizations/memberships_controller.rb
+++ b/app/controllers/organizations/memberships_controller.rb
@@ -158,6 +158,19 @@ class Organizations::MembershipsController < ApplicationController
     end
   end
 
+  def destroy_organization
+    @organization.users_by_organization_in_project(@project).each do |member|
+      if member.deletable?
+        member.destroy
+      end
+    end
+
+    respond_to do |format|
+      format.html { redirect_to settings_project_path(@project, :tab => 'members') }
+      format.js
+    end
+  end
+
   private
 
   def find_organization

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -100,6 +100,10 @@ class Organization < ActiveRecord::Base
     users.joins(:members).where("users.status = ? AND members.project_id = ?", User::STATUS_ACTIVE, project.id)
   end
 
+  def users_by_organization_in_project(project)
+    Member.joins(:user).where("users.organization_id = ? AND members.project_id = ?", self.id, project.id)
+  end
+
   def projects
     Project.where("id IN (?)", self.memberships.pluck(:project_id).uniq)
   end

--- a/app/views/projects/settings/_members.html.erb
+++ b/app/views/projects/settings/_members.html.erb
@@ -50,6 +50,7 @@
                           edit_organizations_membership_path(id: organization.id, project_id: @project.id),
                           :remote => true,
                           :class => 'icon icon-edit' if managed_organizations.include? organization %>
+              <%= link_to l(:button_delete_all), destroy_organization_organizations_membership_path(id: organization.id, project_id: @project.id), :method => :delete, :data => {:confirm => l(:organization_delete_all_confirm)}, :class => 'icon icon-del' %>
             </td>
           </tr>
         <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -29,3 +29,5 @@ en:
   mail_subject_updated_role: "Modification des paramètres de votre compte"
   hello: "Bonjour %{user}"
   label_organizations_roles: Organizations roles
+  button_delete_all: "Delete all"
+  organization_delete_all_confirm: "Are you sure to remove all members of this organization?"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -48,3 +48,5 @@ fr:
   label_direction_only: Seulement les directions
   label_my_organization: Mon organisation
   label_organizations_roles: Rôles des organisations
+  button_delete_all: "Tout supprimer"
+  organization_delete_all_confirm: "Êtes-vous sûr de vouloir supprimer tous les membres de cette organisation ?"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,6 +30,7 @@ RedmineApp::Application.routes.draw do
       member do
         put :update_non_members_roles
         delete :destroy_non_members_roles
+        delete :destroy_organization
       end
     end
   end

--- a/spec/controllers/memberships_controller_spec.rb
+++ b/spec/controllers/memberships_controller_spec.rb
@@ -1,0 +1,47 @@
+require "spec_helper"
+
+describe Organizations::MembershipsController, :type => :controller do
+
+  render_views
+
+  fixtures :organizations, :organization_managers, :users,
+           :organization_team_leaders, :members, :member_roles, :roles, :projects
+
+  describe 'Admin actions' do
+    before do
+      @request.session[:user_id] = 1
+    end
+
+    it "should delete all members from an organization" do
+      user1 = User.find(2)
+      user1.organization = Organization.find(1)
+      user1.save
+      user2 = User.find(3)
+      user2.organization = Organization.find(1)
+      user2.save
+      expect do
+        delete :destroy_organization, :params => {
+          :project_id => 1,
+          :id => 1
+        }
+      end.to change { Member.count }.by(-2)
+    end
+
+    it "should delete all members from an organization except lock one" do
+
+      user1 = User.find(8)
+      user1.organization = Organization.find(1)
+      user1.save
+      user2 = User.find(2)
+      user2.organization = Organization.find(1)
+      user2.save
+
+      expect do
+        delete :destroy_organization, :params => {
+          :project_id => 5,
+          :id => 1
+        }
+      end.to change { Member.count }.by(-1)
+    end
+  end
+end


### PR DESCRIPTION
Réponses au ticket #178881 : 
- Ajout du bouton de suppression de tous les membres d'une organisation dans la page de configuration d'un projet ;
- Ajout des tests associés.