### PR TITLE
Project settings, members tab reloading

### DIFF
--- a/app/views/organizations/memberships/destroy_non_members_roles.erb
+++ b/app/views/organizations/memberships/destroy_non_members_roles.erb
@@ -1,0 +1,2 @@
+$('#tab-content-members').html('<%= escape_javascript(render :partial => 'projects/settings/members') %>');
+hideOnLoad();

--- a/app/views/projects/settings/_non_member_organization.html.erb
+++ b/app/views/projects/settings/_non_member_organization.html.erb
@@ -37,7 +37,7 @@
                            :class => 'icon icon-edit') %>
       <%= link_to(l(:button_delete),
                   destroy_non_members_roles_organizations_membership_path(id: o.id, :project_id => @project.id, :back_url => @back),
-                  :method => :delete, :class => 'icon icon-del', :title => l(:label_relation_delete)) %>
+                  :method => :delete, :class => 'icon icon-del', :title => l(:label_relation_delete), :remote => true) %>
     </td>
   </tr>
 


### PR DESCRIPTION
Adding non-reloading of page when destroy_non_members_roles